### PR TITLE
Fix warnings on missing keys, empty arrays

### DIFF
--- a/src/BlockContent.js
+++ b/src/BlockContent.js
@@ -21,7 +21,7 @@ function BlockContent(props) {
     return opts
   }, {})
 
-  function serializeNode(node) {
+  function serializeNode(node, index) {
     if (isList(node)) {
       return serializeList(node)
     }
@@ -31,17 +31,17 @@ function BlockContent(props) {
     }
 
     if (isSpan(node)) {
-      return serializeSpan(node, serializers)
+      return serializeSpan(node, serializers, index)
     }
 
-    return serializeBlock(node)
+    return serializeBlock(node, index)
   }
 
-  function serializeBlock(block) {
+  function serializeBlock(block, index) {
     const tree = buildMarksTree(block)
     const children = tree.map(serializeNode)
     const blockProps = {
-      key: block._key,
+      key: block._key || `block-${index}`,
       node: block,
       serializers,
       options
@@ -65,7 +65,11 @@ function BlockContent(props) {
   }
 
   const nodes = blocks.map(serializeNode)
-  return nodes.length > 1 ? h('div', {className: props.className}, nodes) : nodes[0]
+  if (nodes.length > 1) {
+    return h('div', {className: props.className}, nodes)
+  }
+
+  return nodes[0] || null
 }
 
 function isList(block) {

--- a/src/serializers.js
+++ b/src/serializers.js
@@ -79,17 +79,17 @@ function ImageSerializer(props) {
 }
 
 // Serializer that recursively calls itself, producing a React tree of spans
-function serializeSpan(span, serializers) {
+function serializeSpan(span, serializers, index) {
   if (typeof span === 'string') {
     return span
   }
 
   const serializedNode = objectAssign({}, span, {
-    children: span.children.map(child => serializeSpan(child, serializers))
+    children: span.children.map((child, i) => serializeSpan(child, serializers, i))
   })
 
   return h(serializers.span, {
-    key: span._key,
+    key: span._key || `span-${index}`,
     node: serializedNode,
     serializers
   })

--- a/test/BlockContent.test.js
+++ b/test/BlockContent.test.js
@@ -112,6 +112,18 @@ test('sorts marks correctly on equal number of occurences', () => {
   expect(result).toEqual(output)
 })
 
+test('handles keyless blocks/spans', () => {
+  const {input, output} = require('./fixtures/019-keyless')
+  const result = render({blocks: input})
+  expect(result).toEqual(output)
+})
+
+test('handles empty arrays', () => {
+  const {input, output} = require('./fixtures/020-empty-array')
+  const result = render({blocks: input})
+  expect(result).toEqual(output)
+})
+
 test('can specify custom serializer for custom block types', () => {
   const {input, output} = require('./fixtures/050-custom-block-type')
   const CodeRenderer = props => {

--- a/test/fixtures/019-keyless.js
+++ b/test/fixtures/019-keyless.js
@@ -1,0 +1,39 @@
+module.exports = {
+  input: [
+    {
+      _type: 'block',
+      children: [
+        {
+          _type: 'span',
+          marks: [],
+          text: 'sanity'
+        },
+        {
+          _type: 'span',
+          marks: [],
+          text: ' is a full time job'
+        }
+      ],
+      markDefs: [],
+      style: 'normal'
+    },
+    {
+      _type: 'block',
+      children: [
+        {
+          _type: 'span',
+          marks: [],
+          text: 'in a world that '
+        },
+        {
+          _type: 'span',
+          marks: [],
+          text: 'is always changing'
+        }
+      ],
+      markDefs: [],
+      style: 'normal'
+    },
+  ],
+  output: '<div><p>sanity is a full time job</p><p>in a world that is always changing</p></div>'
+}

--- a/test/fixtures/020-empty-array.js
+++ b/test/fixtures/020-empty-array.js
@@ -1,0 +1,4 @@
+module.exports = {
+  input: [],
+  output: ''
+}


### PR DESCRIPTION
Currently, blocks and spans without keys will trigger warnings about missing node keys. While it would be best if the data model had keys, the renderer shouldn't _depend_ on them, but rather fall back to a less optimal index-based keying.

Also fixes an issue where an empty array of blocks would return `undefined` instead of `null`, which React doesn't like.
