### PR TITLE
Set proper display name on block content renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "envify": "^4.1.0",
     "eslint": "^4.14.0",
     "eslint-config-prettier": "^2.4.0",
-    "eslint-config-sanity": "^3.0.1",
+    "eslint-config-sanity": "^4.0.2",
     "eslint-plugin-import": "^2.7.0",
     "jest": "^22.0.4",
     "prettier": "^1.7.0",

--- a/src/BlockContent.js
+++ b/src/BlockContent.js
@@ -8,15 +8,18 @@ const {
 
 const renderNode = React.createElement
 const {defaultSerializers} = getSerializers(renderNode)
-const BlockContent = blocksToNodes.bind(null, renderNode)
+
+const SanityBlockContent = props => {
+  return blocksToNodes(renderNode, Object.assign({blocks: []}, props))
+}
 
 // Expose default serializers to the user
-BlockContent.defaultSerializers = defaultSerializers
+SanityBlockContent.defaultSerializers = defaultSerializers
 
 // Expose logic for building image URLs from an image reference/node
-BlockContent.getImageUrl = getImageUrl
+SanityBlockContent.getImageUrl = getImageUrl
 
-BlockContent.propTypes = {
+SanityBlockContent.propTypes = {
   className: PropTypes.string,
 
   // When rendering images, we need project id and dataset, unless images are materialized
@@ -50,9 +53,9 @@ BlockContent.propTypes = {
   ]).isRequired
 }
 
-BlockContent.defaultProps = {
-  serializers: BlockContent.defaultSerializers,
+SanityBlockContent.defaultProps = {
+  serializers: SanityBlockContent.defaultSerializers,
   imageOptions: {}
 }
 
-module.exports = BlockContent
+module.exports = SanityBlockContent

--- a/test/BlockContent.test.js
+++ b/test/BlockContent.test.js
@@ -14,3 +14,7 @@ const normalize = html =>
   })
 
 runTests({render, h, normalize, getImageUrl})
+
+test('renders empty block with react proptype error', () => {
+  expect(h(BlockContent, {})).toMatchSnapshot()
+})

--- a/test/__snapshots__/BlockContent.test.js.snap
+++ b/test/__snapshots__/BlockContent.test.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders empty block with react proptype error 1`] = `
+<SanityBlockContent
+  imageOptions={Object {}}
+  serializers={
+    Object {
+      "block": [Function],
+      "hardBreak": [Function],
+      "list": [Function],
+      "listItem": [Function],
+      "marks": Object {
+        "code": [Function],
+        "em": [Function],
+        "link": [Function],
+        "strike-through": [Function],
+        "strong": [Function],
+        "underline": [Function],
+      },
+      "span": [Function],
+      "types": Object {
+        "block": [Function],
+        "image": [Function],
+      },
+    }
+  }
+/>
+`;


### PR DESCRIPTION
This PR makes the display name of the component `SanityBlockContent`, which should be easier to debug than `bound blocksToNodes`