### PR TITLE
Fixing block-content-to-react#6

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Sanity <hello@sanity.io>",
   "license": "MIT",
   "dependencies": {
-    "@sanity/block-content-to-hyperscript": "^1.3.1",
+    "@sanity/block-content-to-hyperscript": "^1.3.2",
     "prop-types": "^15.6.1"
   },
   "devDependencies": {

--- a/src/BlockContent.js
+++ b/src/BlockContent.js
@@ -13,7 +13,12 @@ const SanityBlockContent = props => {
     props.serializers
   )
 
-  return blocksToNodes(renderNode, Object.assign({}, defaultProps, props, {serializers: customSerializers}), serializers, serializeSpan)
+  return blocksToNodes(
+    renderNode,
+    Object.assign({}, defaultProps, props, {serializers: customSerializers}),
+    serializers,
+    serializeSpan
+  )
 }
 
 // Expose default serializers to the user

--- a/src/BlockContent.js
+++ b/src/BlockContent.js
@@ -1,10 +1,9 @@
 const React = require('react')
 const PropTypes = require('prop-types')
 const internals = require('@sanity/block-content-to-hyperscript/internals')
-const {serializers, renderProps} = require('./targets/dom')
+const {serializers, serializeSpan, renderProps} = require('./targets/dom')
 
 const {getImageUrl, blocksToNodes, mergeSerializers} = internals
-
 const renderNode = React.createElement
 const defaultProps = Object.assign({blocks: []}, renderProps)
 
@@ -14,10 +13,7 @@ const SanityBlockContent = props => {
     props.serializers
   )
 
-  return blocksToNodes(
-    renderNode,
-    Object.assign({}, defaultProps, props, {serializers: customSerializers})
-  )
+  return blocksToNodes(renderNode, Object.assign({}, defaultProps, props, {serializers: customSerializers}), serializers, serializeSpan)
 }
 
 // Expose default serializers to the user

--- a/src/targets/dom.js
+++ b/src/targets/dom.js
@@ -2,9 +2,10 @@ const React = require('react')
 const {getSerializers} = require('@sanity/block-content-to-hyperscript/internals')
 
 const renderNode = React.createElement
-const {defaultSerializers} = getSerializers(renderNode)
+const {defaultSerializers, serializeSpan} = getSerializers(renderNode)
 
 module.exports = {
+  serializeSpan,
   serializers: defaultSerializers,
   renderProps: {nestMarks: true}
 }

--- a/src/targets/react-native.js
+++ b/src/targets/react-native.js
@@ -110,7 +110,7 @@ const ListItemSerializer = props => {
 
 const HardBreakSerializer = () => h(Text, null, '\n')
 
-const {defaultSerializers} = getSerializers(h)
+const {defaultSerializers, serializeSpan} = getSerializers(h)
 const serializers = mergeSerializers(defaultSerializers, {
   // Common overrides
   types: {
@@ -138,5 +138,6 @@ const serializers = mergeSerializers(defaultSerializers, {
 
 module.exports = {
   serializers,
+  serializeSpan,
   renderProps: {listNestMode: 'normal'}
 }

--- a/test/dom/BlockContent.test.js
+++ b/test/dom/BlockContent.test.js
@@ -3,6 +3,7 @@ const React = require('react')
 const ReactDOM = require('react-dom/server')
 const runTests = require('@sanity/block-content-tests')
 const BlockContent = require('../../src/BlockContent')
+const reactTestRenderer = require('react-test-renderer')
 
 const h = React.createElement
 const getImageUrl = BlockContent.getImageUrl
@@ -17,4 +18,46 @@ runTests({render, h, normalize, getImageUrl})
 
 test('renders empty block with react proptype error', () => {
   expect(render({})).toMatchSnapshot()
+})
+
+test('should reuse serializers', () => {
+  const block = {
+    _key: '58cf8aa1fc74',
+    _type: 'sometype',
+    something: {someProperty: 'someValue'}
+  }
+
+  let numMounts = 0
+  class RootComponent extends React.Component {
+    constructor() {
+      super()
+      this.serializers = {
+        types: {
+          sometype: class SometypeComponent extends React.Component {
+            // eslint-disable-next-line class-methods-use-this
+            componentDidMount() {
+              numMounts += 1
+            }
+
+            render() {
+              return React.createElement('div', {}, `Hello ${this.props.msg}`)
+            }
+          }
+        }
+      }
+    }
+
+    render() {
+      return React.createElement(BlockContent, {
+        serializers: this.serializers,
+        blocks: [block],
+        msg: this.props.msg
+      })
+    }
+  }
+
+  const element = React.createElement(RootComponent, {msg: 'there'}, null)
+  const renderer = reactTestRenderer.create(element)
+  renderer.update(React.createElement(RootComponent, {msg: 'you'}, null))
+  expect(numMounts).toBe(1)
 })


### PR DESCRIPTION
Moving serializer instantiation out of blocksToNodes, fixing #6 .

Note: Requires https://github.com/sanity-io/block-content-to-hyperscript/pull/3 